### PR TITLE
fix: cwd() in Windows

### DIFF
--- a/src/lib/remark.js
+++ b/src/lib/remark.js
@@ -27,7 +27,7 @@ export default function examples(options) {
         const i = examples.length
 
         const parentId = toPOSIX(
-          file.history[0].split(process.cwd())[1].slice(1),
+          file.history[0].split(toPOSIX(process.cwd()))[1].slice(1),
         )
         const mdFilename = toPOSIX(
           path.basename(parentId, path.extname(parentId)),


### PR DESCRIPTION
this is a small fix for #2 

`file.history[0]` is using forward slashes but in `Windows process.cwd()` returns a path with backslashes.