### PR TITLE
fix: support tsx with wrapper

### DIFF
--- a/src/lib/remark.js
+++ b/src/lib/remark.js
@@ -412,6 +412,7 @@ function createWrapperSrc({ lang, inner, outer }) {
     <Inner {...$$restProps}/>
 </Outer>`
     case 'jsx':
+    case 'tsx':
       return `\
 import Inner from ${JSON.stringify(inner)}
 import Outer from ${JSON.stringify(outer)}


### PR DESCRIPTION
Fix error when using TSX with a wrapper.

<img width="990" alt="Screenshot 2024-08-19 at 16 03 38" src="https://github.com/user-attachments/assets/c3893ef1-2d72-4aee-9080-05c6b8a8fd3c">
