### PR TITLE
Fixes TS error when using in astro.config.ts file

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "files": [
     "src/lib"
   ],
+  "main": "./src/lib/index.js",
+  "types": "./src/lib/index.d.ts",
   "exports": {
     ".": "./src/lib/index.js",
     "./components": "./src/lib/components/index.js",

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -1,0 +1,3 @@
+declare function liveCode(options?: any): any;
+
+export default liveCode;


### PR DESCRIPTION
The package is not written in TS, which is fine, but the error it gave was a bit annoying. Had to place `@ts-ignore` in my astro.config.ts.

This PR removes this error, by simply giving the plugin a type of `any`.

No other changes made, no downsides. Just type any.